### PR TITLE
Display APOD title on date search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/apod_viewer (2).py
+++ b/apod_viewer (2).py
@@ -47,10 +47,10 @@ class DateFrame(ttk.Frame):
         self.date_var = tk.StringVar(value=datetime.date.today().isoformat())
         ttk.Entry(self, textvariable=self.date_var).pack(pady=5)
         ttk.Button(self, text="Fetch", command=self.fetch_apod).pack(pady=5)
+        self.title_label = ttk.Label(self, wraplength=700, font=(None, 14, "bold"))
+        self.title_label.pack(pady=(10, 0))
         self.image_label = ttk.Label(self)
         self.image_label.pack(pady=10)
-        self.caption = ttk.Label(self, wraplength=700)
-        self.caption.pack()
 
     def fetch_apod(self):
         date_str = self.date_var.get()
@@ -73,7 +73,7 @@ class DateFrame(ttk.Frame):
         photo = ImageTk.PhotoImage(img)
         self.image_label.config(image=photo)
         self.image_label.image = photo
-        self.caption.config(text=data.get("title", ""))
+        self.title_label.config(text=data.get("title", ""))
 
 class GalleryFrame(ttk.Frame):
     def __init__(self, parent, controller):


### PR DESCRIPTION
## Summary
- show APOD title label on the date search page
- ignore Python cache files

## Testing
- `python3 -m py_compile 'apod_viewer (2).py'`

------
https://chatgpt.com/codex/tasks/task_e_6848ae519bd0832bb4246da656796431